### PR TITLE
Temporarily revert to dockerhub

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.10.2"
 description: A Helm chart for kured
 name: kured
-version: 4.0.0
+version: 4.0.1
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/kubereboot/kured
+  repository: weaveworks/kured
   tag: ""  # will default to the appVersion in Chart.yaml
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
Until we fix ghcr, we can still use the old dockerhub images.

Signed-off-by: Jean-Philippe Evrard <open-source@a.spamming.party>
