### PR TITLE
Add possibility to define an initContainer for the DaemonSet

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.12.0"
 description: A Helm chart for kured
 name: kured
-version: 4.2.0
+version: 4.3.0
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -129,6 +129,7 @@ The following changes have been made compared to the stable chart:
 | `nodeSelector`          | Node Selector for the daemonset (ie, restrict which nodes kured runs on)                    | `{}`                      |
 | `volumeMounts`          | Maps of volumes mount to mount                                                              | `{}`                      |
 | `volumes`               | Maps of volumes to mount                                                                    | `{}`                      |
+| `initContainers`        | Define initContainers for DaemonSet                                                         | `{}`                      |
 See https://github.com/kubereboot/kured#configuration for values (not contained in the `configuration` object) for `extraArgs`. Note that
 ```yaml
 extraArgs:

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -46,6 +46,12 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.initContainers }}
+          {{- with .Values.initContainers }}
+      initContainers:
+{{ toYaml . | indent 8 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -102,3 +102,5 @@ nodeSelector: {}
 volumeMounts: []
 
 volumes: []
+
+initContainers: {}


### PR DESCRIPTION
If you want to prepare the node for automatic reboots e.g. by installing a specific script which is triggered by the reboot cmd, a custom initContainer could become handy.

This PR allows to specify an optional initContainer in the `values.yaml` like this:
```
initContainers:
  - command:
      - sh
      - -c
      - echo \"This could be an init container\"; sleep 10s;
    image: busybox
    imagePullPolicy: IfNotPresent
    name: init-test
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
```