### PR TITLE
Expose --drain-pod-selector

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.13.1"
 description: A Helm chart for kured
 name: kured
-version: 4.6.0
+version: 4.7.0
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -84,6 +84,7 @@ The following changes have been made compared to the stable chart:
 | `configuration.forceReboot`             | cli-parameter `--force-reboot`                                              | `false`                   |
 | `configuration.drainGracePeriod`        | cli-parameter `--drain-grace-period`                                        | `""`                      |
 | `configuration.drainTimeout`            | cli-parameter `--drain-timeout`                                             | `""`                      |
+| `configuration.drainPodSelector`        | cli-parameter `--drain-pod-selector`                                        | `""`                      |
 | `configuration.skipWaitForDeleteTimeout` | cli-parameter `--skip-wait-for-delete-timeout`                             | `""`                      |
 | `configuration.prometheusUrl`           | cli-parameter `--prometheus-url`                                            | `""`                      |
 | `configuration.rebootDays`              | Array of days for multiple cli-parameters `--reboot-days`                   | `[]`                      |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -95,6 +95,9 @@ spec:
           {{- if .Values.configuration.drainGracePeriod }}
             - --drain-grace-period={{ .Values.configuration.drainGracePeriod }}
           {{- end }}
+          {{- if .Values.configuration.drainPodSelector }}
+            - --drain-pod-selector={{ .Values.configuration.drainPodSelector }}
+          {{- end }}
           {{- if .Values.configuration.drainTimeout }}
             - --drain-timeout={{ .Values.configuration.drainTimeout }}
           {{- end }}

--- a/charts/kured/values.minikube.yaml
+++ b/charts/kured/values.minikube.yaml
@@ -12,6 +12,7 @@ configuration:
   period: "1m"                    # reboot check period (default 1h0m0s)
   # forceReboot: false            # force a reboot even if the drain fails or times out (default: false)
   # drainGracePeriod: ""          # time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
+  # drainPodSelector: ""          # only drain pods with labels matching the selector (default: '', all pods)
   # drainTimeout: ""              # timeout after which the drain is aborted (default: 0, infinite time)
   # skipWaitForDeleteTimeout: ""  # when time is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
   # prometheusUrl: ""             # Prometheus instance to probe for active alerts

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -32,6 +32,7 @@ configuration:
   period: ""                    # reboot check period (default 1h0m0s)
   forceReboot: false            # force a reboot even if the drain fails or times out (default: false)
   drainGracePeriod: ""          # time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
+  drainPodSelector: ""          # only drain pods with labels matching the selector (default: '', all pods)
   drainTimeout: ""              # timeout after which the drain is aborted (default: 0, infinite time)
   skipWaitForDeleteTimeout: ""  # when time is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
   prometheusUrl: ""             # Prometheus instance to probe for active alerts


### PR DESCRIPTION
Exposes the --drain-pod-selector cli parameter introduced with [kureboot/kured#788](https://github.com/kubereboot/kured/pull/788#discussion_r1245878097) through the helm chart