### PR TITLE
feat: allow changing the default revisionHistoryLimit

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.13.2"
 description: A Helm chart for kured
 name: kured
-version: 5.0.0
+version: 5.1.0
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -74,6 +74,7 @@ The following changes have been made compared to the stable chart:
 | `image.tag`                             | Image tag                                                                   | `1.13.2`                  |
 | `image.pullPolicy`                      | Image pull policy                                                           | `IfNotPresent`            |
 | `image.pullSecrets`                     | Image pull secrets                                                          | `[]`                      |
+| `revisionHistoryLimit`                  | Number of old history to retain to allow rollback                           | `10`                      |
 | `updateStrategy`                        | Daemonset update strategy                                                   | `RollingUpdate`           |
 | `maxUnavailable`                        | The max pods unavailable during a rolling update                            | `1`                       |
 | `podAnnotations`                        | Annotations to apply to pods (eg to add Prometheus annotations)             | `{}`                      |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -12,9 +12,7 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
-{{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-{{- end }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
 {{- if eq .Values.updateStrategy "RollingUpdate"}}

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -12,6 +12,9 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
+{{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+{{- end }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
 {{- if eq .Values.updateStrategy "RollingUpdate"}}

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -4,6 +4,8 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
+# revisionHistoryLimit: 1  # number of old history to retain to allow rollback (Kubernetes default 10)
+
 updateStrategy: RollingUpdate
 #  requires RollingUpdate updateStrategy
 maxUnavailable: 1

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -4,7 +4,7 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
-# revisionHistoryLimit: 1  # number of old history to retain to allow rollback (Kubernetes default 10)
+revisionHistoryLimit: 10
 
 updateStrategy: RollingUpdate
 #  requires RollingUpdate updateStrategy


### PR DESCRIPTION
You may want to clean up old ReplicaSets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore you want to overwrite the Kubernetes default revision history limit.

See [Kubernetes Clean up Policy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy).
_(also available for DaemonSets but not yet documented [here](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/), instead please see [openapi-spec](https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json))_