### PR TITLE
feat: add drainDelay configuration property

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.14.1"
 description: A Helm chart for kured
 name: kured
-version: 5.3.1
+version: 5.3.2
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: chopf

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -93,6 +93,7 @@ The following changes have been made compared to the stable chart:
 | `configuration.lockAnnotation`          | cli-parameter `--lock-annotation`                                           | `""`                      |
 | `configuration.period`                  | cli-parameter `--period`                                                    | `""`                      |
 | `configuration.forceReboot`             | cli-parameter `--force-reboot`                                              | `false`                   |
+| `configuration.drainDelay`              | cli-parameter `--drain-delay`                                               | `0`                       |
 | `configuration.drainGracePeriod`        | cli-parameter `--drain-grace-period`                                        | `""`                      |
 | `configuration.drainTimeout`            | cli-parameter `--drain-timeout`                                             | `""`                      |
 | `configuration.drainPodSelector`        | cli-parameter `--drain-pod-selector`                                        | `""`                      |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -108,6 +108,9 @@ spec:
           {{- if .Values.configuration.drainPodSelector }}
             - --drain-pod-selector={{ .Values.configuration.drainPodSelector }}
           {{- end }}
+          {{- if .Values.configuration.drainDelay }}
+            - --drain-delay={{ .Values.configuration.drainDelay }}
+          {{- end }}
           {{- if .Values.configuration.drainTimeout }}
             - --drain-timeout={{ .Values.configuration.drainTimeout }}
           {{- end }}

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -38,6 +38,7 @@ configuration:
   forceReboot: false            # force a reboot even if the drain fails or times out (default: false)
   drainGracePeriod: ""          # time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
   drainPodSelector: ""          # only drain pods with labels matching the selector (default: '', all pods)
+  drainDelay: 0                 # delay drain for this duration (default: 0, disabled)
   drainTimeout: ""              # timeout after which the drain is aborted (default: 0, infinite time)
   skipWaitForDeleteTimeout: ""  # when time is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
   prometheusUrl: ""             # Prometheus instance to probe for active alerts


### PR DESCRIPTION
This PR adds the `drainDelay` configuration property provided by https://github.com/kubereboot/kured/pull/852 