### PR TITLE
add hostPID values template to daemonset.yaml

### DIFF
--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       serviceAccountName: {{ template "kured.serviceAccountName" . }}
       hostNetwork: {{ .Values.hostNetwork }}
-      hostPID: true
+      hostPID: {{ .Values.hostPID }}
       restartPolicy: Always
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
This will put out the hostPID from hardcoded template and allow users with v1.25.1 cluster to change value upon their need to due pod security admission restrictions 