### PR TITLE
71: Fix volume mounting

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.15.0"
 description: A Helm chart for kured
 name: kured
-version: 5.4.1
+version: 5.4.2
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: chopf

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -206,7 +206,7 @@ spec:
             readOnly: true
         {{- end }}
         {{- if .Values.volumeMounts }}
-{{- toYaml .Values.volumeMounts  | nindent 12 }}
+{{- toYaml .Values.volumeMounts  | nindent 10 }}
         {{- end }}
           ports:
             - containerPort: {{ .Values.configuration.metricsPort }}


### PR DESCRIPTION
- As outlined in #71, trying to add a custom volumeMount will fail Helm templating because the mount will be indented too far by two spaces. This resolves issue.