### PR TITLE
feat: Publish helm chart also as an OCI package to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write  # for helm/chart-releaser-action to push chart release and create a release
+  packages: write  # to push OCI chart package to GitHub Registry
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -23,3 +27,20 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/${{ github.repository }}
+          done

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-Add the repo:
+Add the repo (only needed if you want to use the classical approach without using the [OCI registry](https://helm.sh/docs/topics/registries/)):
 
 ```
 helm repo add kubereboot https://kubereboot.github.io/charts

--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.15.0"
 description: A Helm chart for kured
 name: kured
-version: 5.4.2
+version: 5.4.3
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: chopf

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -5,12 +5,19 @@ This chart installs the "Kubernetes Reboot Daemon" using the Helm Package Manage
 
 ## Prerequisites
 - Kubernetes 1.9+
+- Helm 3.8.0+ (to pull the chart from the OCI registry)
 
 ## Installing the Chart
 To install the chart with the release name `my-release`:
 ```bash
 $ helm repo add kubereboot https://kubereboot.github.io/charts
 $ helm install my-release kubereboot/kured
+```
+
+You can also pull the helm chart from the OCI registry `ghcr.io`:
+
+```bash
+$ helm install my-release oci://ghcr.io/kubereboot/charts/kured
 ```
 
 ## Uninstalling the Chart


### PR DESCRIPTION
This PR adds support to also publish the helm chart to the OCI registry ghcr.io.

I am a argo-helm maintainer and the code is already in use for a couple of months there:
- https://github.com/argoproj/argo-helm/blob/fa85e824f014ef7bf19163d4ecf7e9b8eb01f6b9/.github/workflows/publish.yml#L67C15-L82
- https://github.com/argoproj/argo-helm/pull/2209

Related background info:
- https://blog.bitnami.com/2023/04/httpsblog.bitnami.com202304bitnami-helm-charts-now-oci.html?m=1
- https://helm.sh/docs/topics/registries/