### PR TITLE
feat: Add release note to each GitHub release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,3 +23,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true


### PR DESCRIPTION
Resolves #74

These repositories use exactly this toggle:
- [renovatebot/helm-charts](https://github.com/renovatebot/helm-charts/blob/5457a71d97e5318f3b5c152c332429ddf6a694a7/.github/workflows/release.yaml#L37-L44)
- [nextcloud/helm](https://github.com/nextcloud/helm/blob/9d560de6668ed393f8a8dfa84f5692352cf62ff3/.github/workflows/release.yaml#L39-L43)
- [cloudnative-pg/charts](https://github.com/cloudnative-pg/charts/blob/001d78758b864f8ffd42799f6f44760c0ca5a671/.github/workflows/release-publish.yml#L49)
- [argoproj/argo-helm](https://github.com/argoproj/argo-helm/blob/2f82fb5992fe1e390d1ebdbc4be6d5d6c6549a37/.github/configs/cr.yaml#L12)
- many more ;)