### PR TITLE
update docs for rebootSentinelCommand

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.15.0"
 description: A Helm chart for kured
 name: kured
-version: 5.4.3
+version: 5.4.4
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: chopf

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -109,7 +109,7 @@ The following changes have been made compared to the stable chart:
 | `configuration.prometheusUrl`           | cli-parameter `--prometheus-url`                                            | `""`                      |
 | `configuration.rebootDays`              | Array of days for multiple cli-parameters `--reboot-days`                   | `[]`                      |
 | `configuration.rebootSentinel`          | cli-parameter `--reboot-sentinel`                                           | `""`                      |
-| `configuration.rebootSentinelCommand`   | cli-parameter `--reboot-sentinel-command`                                   | `""`                      |
+| `configuration.rebootSentinelCommand`   | Configure your own reboot command to run on the node host OS. Requires `configuration.useRebootSentinelHostPath` to be set to false. `--reboot-sentinel-command`                                   | `""`                      |
 | `configuration.rebootCommand`           | cli-parameter `--reboot-command`                                            | `""`                      |
 | `configuration.rebootDelay`             | cli-parameter `--reboot-delay`                                              | `""`                      |
 | `configuration.rebootMethod`            | cli-parameter `--reboot-method`                                             | `""`                      |


### PR DESCRIPTION
This PR adds clarifying documentation for the `configuration.rebootSentinelCommand` values configuration. Since we ship the README.md as part of the chart, updated the chart one patch version.

Fixes #77