### PR TITLE
use .Release.namespace to align service template

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.17.1"
 description: A Helm chart for kured
 name: kured
-version: 5.6.1
+version: 5.6.2
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: chopf

--- a/charts/kured/templates/service.yaml
+++ b/charts/kured/templates/service.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- else }}
   name: {{ template "kured.fullname" . }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kured.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}


### PR DESCRIPTION
This is a no-op as the install should place the service in the same namespace as the rest of the install regardless, but as per #102 this does align the service template to use `.Release.Namespace` as the other templates do.


Resolves #102 