### PR TITLE
add extra annotations for service accounts

### DIFF
--- a/charts/kured/templates/serviceaccount.yaml
+++ b/charts/kured/templates/serviceaccount.yaml
@@ -6,4 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kured.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.extraAnnotations }}
+    {{ toYaml . }}
+  {{- end }}
 {{- end -}}

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -76,6 +76,7 @@ rbac:
 serviceAccount:
   create: true
   name:
+  extraAnnotations: {}
 
 podSecurityPolicy:
   create: false


### PR DESCRIPTION
Adds the ability to add extra annotations to the created service account

Resolves #112 