### PR TITLE
feat(helm): add annotation key for annotations

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.22.1"
 description: A Helm chart for kured
 name: kured
-version: 5.12.1
+version: 6.0.0
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: chopf

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -30,6 +30,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Upgrade Notes
 
+### From 5.x to 6.x
+
+Service accounts annotations were put into `labels:` which means the users had to edit
+a few things to make annotations work on kured's service account name.
+
+Sadly, this is a breaking change: previous users of .Values.serviceAccount.extraAnnotations will have
+a change of behaviour. If you did not use this, you are not impacted.
+
 ### From 4.x to 5.x
 
 We improved two security-related default-values:

--- a/charts/kured/templates/serviceaccount.yaml
+++ b/charts/kured/templates/serviceaccount.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kured.labels" . | nindent 4 }}
+  annotations:
   {{- with .Values.serviceAccount.extraAnnotations }}
     {{ toYaml . }}
   {{- end }}


### PR DESCRIPTION
Instead of relying on labels, we use annotation.
The idea comes from @dmpe.

This is fair, but a breaking change. Therefore,
we add this to the Chart's README, to clarify the
change's impact.