### PR TITLE
feat: add topologySpreadConstraints support to kured daemonset

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.23.0"
 description: A Helm chart for kured
 name: kured
-version: 6.1.0
+version: 6.2.0
 home: https://github.com/kubereboot/kured
 maintainers:
   - name: chopf

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -159,6 +159,7 @@ The following changes have been made compared to the stable chart:
 | `priorityClassName`     | Priority Class to be used by the pods                                                       | `""`                      |
 | `tolerations`           | Tolerations to apply to the daemonset (eg to allow running on master)                       | `[{"key": "node-role.kubernetes.io/control-plane", "effect": "NoSchedule"}]` for Kubernetes 1.24.0 and greater, otherwise `[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]`|
 | `affinity`              | Affinity for the daemonset (ie, restrict which nodes kured runs on)                         | `{}`                      |
+| `topologySpreadConstraints` | Topology spread constraints for the daemonset pods                                      | `[]`                      |
 | `hostNetwork`           | Pod uses the host network instead of the cluster network                                    | `false`                   |
 | `nodeSelector`          | Node Selector for the daemonset (ie, restrict which nodes kured runs on)                    | `{ "kubernetes.io/os": "linux" }` |
 | `volumeMounts`          | Maps of volumes mount to mount                                                              | `{}`                      |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -246,6 +246,10 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+      {{- end }}
     {{- if or .Values.volumes .Values.configuration.useRebootSentinelHostPath }}
       volumes:
     {{- end }}

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -149,6 +149,8 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 nodeSelector:
   kubernetes.io/os: linux
 


### PR DESCRIPTION
Adds an opt-in `topologySpreadConstraints` value to the kured DaemonSet, mirroring the existing `affinity` / `nodeSelector` / `tolerations` scheduling knobs. Defaults to `[]`, so the rendered output is unchanged unless set.

Validation (local):
- `ct lint --charts charts/kured` passes (helm lint + yamllint + Chart.yaml schema)
- `helm template` default render is byte-identical to main except the chart-version label
- `helm template` with the field set renders `topologySpreadConstraints` in the pod spec
- Chart version bumped 6.0.0 to 6.1.0