### PR TITLE
Update maintainers list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,12 +1,12 @@
 In alphabetical order:
 
-Christian Hopf <christian.kotzbauer@gmail.com> (@ckotzbauer)
-Hidde Beydals <hidde@hhh.computer> (@hiddeco)
+Dharsan Baskar <git@dharsanb.com> (@dharsanb)
 Jack Francis <jackfrancis@gmail.com> (@jackfrancis)
 Jean-Philippe Evrard <open-source@a.spamming.party> (@evrardjp)
 
 Retired maintainers:
 
 - Daniel Holbach
+- Christian Hopf
 
 Thank you for your involvement, and let us not say "farewell" ...


### PR DESCRIPTION
We are refreshing the metadata for the new CNCF .project handling.

This is the time to clean up some outdated information.

Again, huge thanks to all contributors, and particularly those new emeritus maintainers.